### PR TITLE
scroll to top on route change

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -29,8 +29,9 @@ class IacApp extends App {
         }
 
         trackPageView(this.props.router.pathname);
-        Router.events.on('routeChangeComplete', (url) => {
-            trackPageView(this.props.router.pathname)
+        Router.events.on('routeChangeComplete', () => {
+            trackPageView(this.props.router.pathname);
+            window.scrollTo(0, 0);
         });
     }
 


### PR DESCRIPTION
Ben had asked about this sometime last week. This should help. I haven't dug into why it still scrolls to below the breadcrumb and category title.